### PR TITLE
Analyze class references section

### DIFF
--- a/source/AnalysisRecords.hpp
+++ b/source/AnalysisRecords.hpp
@@ -106,12 +106,15 @@ struct AnalysisRecords {
     /// All classes indexed during analysis.
     std::vector<ClassRecord> classes;
 
-    /// All selector references indexed during analysis.
-    std::unordered_map<uint64_t, SelectorRefRecord> selectorRefs;
+    /// List of all known method implementation functions.
+    std::set<uint64_t> imps;
 
     /// Map of selector name addresses to method implementations.
     std::unordered_map<uint64_t, uint64_t> impMap;
 
-    /// List of all known method implementation functions.
-    std::set<uint64_t> imps;
+    /// All selector references indexed during analysis.
+    std::unordered_map<uint64_t, SelectorRefRecord> selectorRefs;
+
+    /// Map of class addresses to class reference addresses.
+    std::unordered_map<uint64_t, uint64_t> reverseClassRefs;
 };

--- a/source/StructureAnalyzer.hpp
+++ b/source/StructureAnalyzer.hpp
@@ -43,6 +43,7 @@ namespace SectionName {
 constexpr auto CFString = "__cfstring";
 constexpr auto ClassList = "__objc_classlist";
 constexpr auto SelectorRefs = "__objc_selrefs";
+constexpr auto ClassRefs = "__objc_classrefs";
 
 }
 
@@ -101,6 +102,9 @@ class StructureAnalyzer {
 
     /// Analyze a selector reference.
     SelectorRefRecord analyzeSelectorRef(uint64_t);
+
+    /// Analyze a class reference.
+    uint64_t analyzeClassRef(uint64_t);
 
     /// Analyze a method.
     MethodRecord analyzeMethod(uint64_t);


### PR DESCRIPTION
- Add `reverseClassRefs` map to `AnalysisRecords` class to map class reference
pointers to the respective class's address

- Add `analyzeClassRef` method to `StructureAnalyzer`, responsible for
analyzing (and fixing) class references

- Add `__objc_classrefs` section processing to the default `StructureAnalyzer`
analysis, naming procedure

Resolves: https://github.com/jonpalmisc/ObjectiveNinja/issues/6